### PR TITLE
Swagger implement

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rangefilter",
     "rest_framework.authtoken",
+    'rest_framework_swagger',
     # local
     "apps.users",
     "apps.logs",

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -20,6 +20,9 @@ from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
 from apps.surveys18.views import Surveys2018Index
+from rest_framework_swagger.views import get_swagger_view
+
+schema_view = get_swagger_view(title='Pastebin API',)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -28,6 +31,7 @@ urlpatterns = [
     path("users/", include("apps.users.urls", namespace="users")),
     path("surveys18/", include("apps.surveys18.urls", namespace="surveys18")),
     path("surveys19/", include("apps.surveys19.urls", namespace="surveys19")),
+    path('api/docs/', schema_view),
 ]
 
 if settings.DEBUG:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,5 @@
 Django>=2.1.7
-djangorestframework==3.9.2
+djangorestframework==3.8.2
 django-crispy-forms==1.7.2
 django-model-utils==3.1.2
 Pillow==5.0.0
@@ -8,3 +8,4 @@ Markdown==2.6.11
 django-admin-rangefilter==0.3.14
 psycopg2==2.7.3.2
 flake8==3.7.7
+django-rest-swagger==2.2.0


### PR DESCRIPTION
Install djange rest swagger
Downgrade django rest framework 3.9.2 > 3.8.2
Because swagger not support newest rest framework
Issue #16 