### PR TITLE
Fix reviewlog query survey

### DIFF
--- a/src/apps/logs/models.py
+++ b/src/apps/logs/models.py
@@ -85,11 +85,18 @@ def query_by_args(request, **kwargs):
     total = queryset.count()
 
     if search_value:
-        queryset = queryset.filter(
-            Q(survey__farmer_id__icontains=search_value)
-            | Q(user__full_name__icontains=search_value)
-            | Q(user__email__icontains=search_value)
-        )
+        if app_label == 'surveys18':
+            queryset = queryset.filter(
+                Q(surveys18__farmer_id__icontains=search_value)
+                | Q(user__full_name__icontains=search_value)
+                | Q(user__email__icontains=search_value)
+            )
+        if app_label == 'surveys19':
+            queryset = queryset.filter(
+                Q(surveys19__farmer_id__icontains=search_value)
+                | Q(user__full_name__icontains=search_value)
+                | Q(user__email__icontains=search_value)
+            )
 
     count = queryset.count()
     queryset = queryset.order_by(order_column)[start: start + length]

--- a/src/apps/surveys18/models.py
+++ b/src/apps/surveys18/models.py
@@ -136,7 +136,7 @@ class Survey(Model):
         verbose_name=_("Updated"),
     )
 
-    review_logs = GenericRelation(ReviewLog, related_query_name="survey")
+    review_logs = GenericRelation(ReviewLog, related_query_name="surveys18")
 
     class Meta:
         verbose_name = _("Survey")

--- a/src/apps/surveys19/models.py
+++ b/src/apps/surveys19/models.py
@@ -20,6 +20,7 @@ from django.db.models import (
     FileField,
     Q,
 )
+from apps.logs.models import ReviewLog
 
 
 YES_NO_CHOICES = ((0, "No"), (1, "Yes"))
@@ -79,6 +80,8 @@ class Survey(Model):
         blank=True,
         verbose_name=_("Updated"),
     )
+
+    review_logs = GenericRelation(ReviewLog, related_query_name="surveys19")
 
     class Meta:
         verbose_name = _("Survey")


### PR DESCRIPTION
ReviewLog use same name 'survey' to query survey18 and survey19.
If model use same related query name only one can active.
Give survey18 and survey19 their own related query name.
ReviewLog can process different survey query.