### PR TITLE
Add survey simple api

### DIFF
--- a/src/apps/surveys18/serializers.py
+++ b/src/apps/surveys18/serializers.py
@@ -402,6 +402,13 @@ class BusinessSerializer(ModelSerializer):
         extra_kwargs = {"farm_related_business": {"validators": []}}
 
 
+class SurveySimpleSerializer(ModelSerializer):
+
+    class Meta:
+        model = Survey
+        fields = "__all__"
+
+
 class SurveySerializer(ModelSerializer):
     app_label = SerializerMethodField(read_only=True)
     model = SerializerMethodField(read_only=True)

--- a/src/apps/surveys18/views.py
+++ b/src/apps/surveys18/views.py
@@ -179,6 +179,10 @@ class SurveyViewSet(ModelViewSet):
     def get_object(self, pk):
         return Survey.objects.get(id=pk)
 
+    @action(methods=["GET"], detail=False, serializer_class=serializers.SurveySimpleSerializer)
+    def simple_list(self, request):
+        return super().list(request)
+
     @action(methods=["PATCH"], detail=False)
     def patch(self, request):
         try:

--- a/src/apps/surveys19/serializers.py
+++ b/src/apps/surveys19/serializers.py
@@ -394,6 +394,13 @@ class MonthSerializer(ModelSerializer):
         fields = "__all__"
 
 
+class SurveySimpleSerializer(ModelSerializer):
+
+    class Meta:
+        model = Survey
+        fields = "__all__"
+
+
 class SurveySerializer(ModelSerializer):
     app_label = SerializerMethodField(read_only=True)
     model = SerializerMethodField(read_only=True)

--- a/src/apps/surveys19/views.py
+++ b/src/apps/surveys19/views.py
@@ -107,6 +107,7 @@ from .serializers import (
     RefuseReasonSerializer,
     MonthSerializer,
     BuilderFileSerializer,
+    SurveySimpleSerializer,
 )
 
 logger = logging.getLogger('django.request')
@@ -235,6 +236,10 @@ class SurveyViewSet(ModelViewSet):
         else:
             permission_classes = [IsAdminUser]
         return [permission() for permission in permission_classes]
+
+    @action(methods=["GET"], detail=False, serializer_class=SurveySimpleSerializer)
+    def simple_list(self, request):
+        return super().list(request)
 
     @action(methods=["PATCH"], detail=False)
     def patch(self, request):


### PR DESCRIPTION
OneToOne field shown as key and dict value, other field shown
as key and list value in nested drf api.

When R use rbind method to process data, the format key and
dict value raise duplicate error.

So new a surveysimple serializer, return when request method
is get and url is simple_list.